### PR TITLE
Prometheus custom metrics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,9 +12,10 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    mustermann (1.0.3)
+    mustermann (1.1.0)
+      ruby2_keywords (~> 0.0.1)
     parallel (1.19.1)
-    parser (2.6.5.0)
+    parser (2.7.0.1)
       ast (~> 2.4.0)
     passenger (6.0.4)
       rack
@@ -37,6 +38,7 @@ GEM
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
     ruby-progressbar (1.10.1)
+    ruby2_keywords (0.0.1)
     sinatra (2.0.7)
       mustermann (~> 1.0)
       rack (~> 2.0)


### PR DESCRIPTION
This PR adds a custom metric to Prometheus named `tree_deploy_counter`. The metric is incremented by calling the deploy_tree method.

Update docs to include an example of the metrics provided and to better outline some things that are helpful during development.